### PR TITLE
feat: scope access tokens by user

### DIFF
--- a/src/app/api/ml/auth/callback/route.ts
+++ b/src/app/api/ml/auth/callback/route.ts
@@ -68,9 +68,9 @@ export async function GET(request: NextRequest) {
     });
 
     // Store token and user info in cache
-    await cache.setUser('access_token', {
+    await cache.setUser(`access_token:${tokenData.user_id}`, {
       token: tokenData.access_token,
-      expires_at: new Date(Date.now() + (tokenData.expires_in * 1000)).toISOString(),
+      expires_at: new Date(Date.now() + tokenData.expires_in * 1000).toISOString(),
       user_id: tokenData.user_id
     });
 

--- a/src/app/api/ml/sync/route.ts
+++ b/src/app/api/ml/sync/route.ts
@@ -20,7 +20,8 @@ export async function POST(request: NextRequest) {
 
     try {
       // Get access token from cache
-      const tokenData = await cache.getUser('access_token');
+      const userId = process.env.ML_USER_ID!;
+      const tokenData = await cache.getUser(`access_token:${userId}`);
       if (!tokenData || !tokenData.token) {
         return NextResponse.json(
           { error: 'No access token found. Please authorize with Mercado Livre first.' },

--- a/src/app/api/products/route.ts
+++ b/src/app/api/products/route.ts
@@ -18,7 +18,8 @@ export async function GET(request: NextRequest) {
       
       try {
         // Get access token from cache
-        const tokenData = await cache.getUser('access_token');
+        const userId = process.env.ML_USER_ID!;
+        const tokenData = await cache.getUser(`access_token:${userId}`);
         
         if (tokenData && tokenData.token) {
           // Check if token is not expired


### PR DESCRIPTION
## Summary
- scope cached ML access token by user id
- fetch user-scoped token in sync and products routes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint src/app/api/ml/auth/callback/route.ts src/app/api/ml/sync/route.ts src/app/api/products/route.ts`

------
https://chatgpt.com/codex/tasks/task_e_68c45745defc8329821e45a512e5b203