### PR TITLE
Track MercadoLivre token expiry

### DIFF
--- a/src/lib/ml-api.ts
+++ b/src/lib/ml-api.ts
@@ -16,6 +16,7 @@ class MercadoLivreAPI {
   private accessToken?: string;
   private refreshToken?: string;
   private userId?: string;
+  private tokenExpiry?: number;
 
   constructor() {
     this.clientId = process.env.ML_CLIENT_ID!;
@@ -78,6 +79,7 @@ class MercadoLivreAPI {
     this.accessToken = tokenData.access_token;
     this.refreshToken = tokenData.refresh_token;
     this.userId = tokenData.user_id.toString();
+    this.tokenExpiry = Date.now() + tokenData.expires_in * 1000;
 
     return tokenData;
   }
@@ -109,6 +111,7 @@ class MercadoLivreAPI {
     const tokenData = await response.json();
     this.accessToken = tokenData.access_token;
     this.refreshToken = tokenData.refresh_token;
+    this.tokenExpiry = Date.now() + tokenData.expires_in * 1000;
 
     return tokenData;
   }
@@ -164,8 +167,8 @@ class MercadoLivreAPI {
   }
 
   private isTokenExpired(): boolean {
-    // Simple check - in production, you'd want to store token expiry time
-    return false;
+    if (!this.tokenExpiry) return false;
+    return Date.now() >= this.tokenExpiry;
   }
 
   private sleep(ms: number): Promise<void> {


### PR DESCRIPTION
## Summary
- persist token expiration timestamp when exchanging or refreshing MercadoLivre tokens
- verify access token validity against stored expiry time

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_68c4585d01408329ad0bfd5f47eea462