### PR TITLE
Gracefully handle missing Mercado Livre token

### DIFF
--- a/src/app/api/ml/webhook/route.ts
+++ b/src/app/api/ml/webhook/route.ts
@@ -134,24 +134,29 @@ async function handleQuestionsWebhook(webhook: MLWebhook): Promise<void> {
     }
 
     console.log(`Processing question update for: ${questionId}`);
-    
+
+    if (!mlApi.hasAccessToken()) {
+      console.log('Skipping question processing: no access token');
+      return;
+    }
+
     // Get question details to find the item ID
     try {
       const question = await mlApi.getQuestion(questionId);
       const itemId = question.item_id;
-      
+
       // Invalidate questions cache for this product
       await cache.invalidateProductQuestions(itemId);
-      
+
       // Fetch fresh questions and update cache
       const questionsResponse = await mlApi.getProductQuestions(itemId);
       await cache.setProductQuestions(itemId, questionsResponse.questions);
-      
+
       // Revalidate product page to show updated Q&A
       await revalidatePath(`/produtos/${itemId}`);
-      
+
       console.log(`Updated questions cache for product: ${itemId}`);
-      
+
     } catch (error) {
       console.error(`Failed to process question ${questionId}:`, error);
       // Don't throw - we still want to acknowledge the webhook
@@ -173,7 +178,12 @@ async function handleOrdersWebhook(webhook: MLWebhook): Promise<void> {
     }
 
     console.log(`Processing order update for: ${orderId}`);
-    
+
+    if (!mlApi.hasAccessToken()) {
+      console.log('Skipping order processing: no access token');
+      return;
+    }
+
     // For now, just log the order update
     // In the future, you might want to:
     // - Update inventory counts

--- a/src/lib/ml-api.ts
+++ b/src/lib/ml-api.ts
@@ -35,6 +35,10 @@ class MercadoLivreAPI {
     }
   }
 
+  hasAccessToken(): boolean {
+    return !!this.accessToken;
+  }
+
   // OAuth Methods
   getAuthUrl(redirectUri: string, state?: string): string {
     const params = new URLSearchParams({
@@ -131,13 +135,18 @@ class MercadoLivreAPI {
           await this.refreshAccessToken();
         }
 
+        const headers: Record<string, string> = {
+          'Content-Type': 'application/json',
+          ...(options.headers as Record<string, string> | undefined)
+        };
+
+        if (this.accessToken) {
+          headers['Authorization'] = `Bearer ${this.accessToken}`;
+        } // if no token, omit Authorization header
+
         const response = await fetch(url, {
           ...options,
-          headers: {
-            'Authorization': `Bearer ${this.accessToken}`,
-            'Content-Type': 'application/json',
-            ...options.headers
-          }
+          headers
         });
 
         if (response.status === 401 && i < retries - 1) {


### PR DESCRIPTION
## Summary
- Avoid sending `Authorization` header when no ML access token is present
- Expose `hasAccessToken` helper on MercadoLivreAPI
- Skip webhook question/order processing when access token is missing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any - 55 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68c45a0586dc83299690f477bb32dd47