### PR TITLE
Refactor cache key enumeration to use scan iterator

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,9 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Limitations
+
+This project uses [Vercel KV](https://vercel.com/docs/storage/vercel-kv) to cache data. Operations that need to inspect or clear
+the cache rely on iterating over keys with `scan`. Scanning is appropriate for small and medium datasets but it requires reading
+through all matching keys and cannot efficiently paginate very large key sets.

--- a/debug-cache.js
+++ b/debug-cache.js
@@ -10,16 +10,25 @@ const kv = createClient({
 async function debugCache() {
   try {
     console.log('🔍 Debugging Cache...\n');
-    
+
+    // Helper to scan keys by pattern
+    async function scanKeys(pattern) {
+      const keys = [];
+      for await (const key of kv.scanIterator({ match: pattern })) {
+        keys.push(key);
+      }
+      return keys;
+    }
+
     // Check all keys
     console.log('1. Getting all keys:');
-    const allKeys = await kv.keys('*');
+    const allKeys = await scanKeys('*');
     console.log('All keys:', allKeys);
     console.log('Total keys:', allKeys.length);
-    
+
     // Check products keys specifically
     console.log('\n2. Getting product keys:');
-    const productKeys = await kv.keys('products:*');
+    const productKeys = await scanKeys('products:*');
     console.log('Product keys:', productKeys);
     
     // Check specific product keys
@@ -47,7 +56,7 @@ async function debugCache() {
     
     // Check individual product keys
     console.log('\n5. Checking individual product keys:');
-    const individualProductKeys = await kv.keys('product:*');
+    const individualProductKeys = await scanKeys('product:*');
     console.log('Individual product keys count:', individualProductKeys.length);
     console.log('Sample individual keys:', individualProductKeys.slice(0, 5));
     


### PR DESCRIPTION
## Summary
- refactor cache utilities to scan key prefixes instead of using `keys`
- update debug script to scan keyspace
- document scanning limitations with large datasets

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_68c45ba8675483299c0ba12f7dfdef80