### PR TITLE
Secure admin routes with bearer token

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,18 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 This project uses [Vercel KV](https://vercel.com/docs/storage/vercel-kv) to cache data. Operations that need to inspect or clear
 the cache rely on iterating over keys with `scan`. Scanning is appropriate for small and medium datasets but it requires reading
 through all matching keys and cannot efficiently paginate very large key sets.
+
+## API Authentication
+
+Sensitive API routes require a bearer token for access. Set the `ADMIN_SECRET` environment variable and include it in requests using the `Authorization` header:
+
+```
+Authorization: Bearer <your token>
+```
+
+This token is required when calling:
+
+- `POST /api/ml/sync`
+- `POST /api/products/[id]`
+
+Requests without the correct token will receive a `401 Unauthorized` response.

--- a/src/app/api/ml/sync/route.ts
+++ b/src/app/api/ml/sync/route.ts
@@ -6,6 +6,12 @@ import { cache } from '@/lib/cache';
 export const maxDuration = 30;
 
 export async function POST(request: NextRequest) {
+  // Require admin token for manual sync
+  const authHeader = request.headers.get('authorization');
+  if (authHeader !== `Bearer ${process.env.ADMIN_SECRET}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
   try {
     console.log('Starting ML sync...');
     

--- a/src/app/api/products/[id]/route.ts
+++ b/src/app/api/products/[id]/route.ts
@@ -141,6 +141,12 @@ export const POST = (async (
   request: NextRequest,
   { params }: { params: { id: string } }
 ) => {
+  // Require admin token for cache updates
+  const authHeader = request.headers.get('authorization');
+  if (authHeader !== `Bearer ${process.env.ADMIN_SECRET}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
   try {
     const { id: productId } = params;
     const { action } = await request.json();


### PR DESCRIPTION
## Summary
- require `Authorization: Bearer ADMIN_SECRET` for manual ML sync
- protect product cache admin endpoint with same bearer token
- document token-based authentication in README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c45d61d1f88329bcc234fa154c3372