### PR TITLE
Refactor cache typing

### DIFF
--- a/src/lib/ml-api.ts
+++ b/src/lib/ml-api.ts
@@ -1,12 +1,13 @@
 import { 
   MLUser, 
   MLProduct, 
-  MLQuestion, 
-  MLOrder, 
-  MLTokenResponse, 
+  MLQuestion,
+  MLOrder,
+  MLCategory,
+  MLTokenResponse,
   MLTokenRefreshResponse,
   MLSearchResult,
-  MLApiResponse 
+  MLApiResponse
 } from '@/types/ml';
 
 class MercadoLivreAPI {
@@ -325,12 +326,12 @@ class MercadoLivreAPI {
   }
 
   // Categories Methods
-  async getCategories(siteId = 'MLB'): Promise<any[]> {
-    return this.makeRequest<any[]>(`/sites/${siteId}/categories`);
+  async getCategories(siteId = 'MLB'): Promise<MLCategory[]> {
+    return this.makeRequest<MLCategory[]>(`/sites/${siteId}/categories`);
   }
 
-  async getCategory(categoryId: string): Promise<any> {
-    return this.makeRequest<any>(`/categories/${categoryId}`);
+  async getCategory(categoryId: string): Promise<MLCategory> {
+    return this.makeRequest<MLCategory>(`/categories/${categoryId}`);
   }
 
   // Utility Methods

--- a/src/types/ml.ts
+++ b/src/types/ml.ts
@@ -377,6 +377,22 @@ export interface CachedQuestions {
   cache_ttl: number;
 }
 
+export interface CachedUser {
+  user_id: number;
+  token?: string;
+  refresh_token?: string;
+  expires_at?: string;
+  nickname?: string;
+  connected_at?: string;
+  [key: string]: unknown;
+}
+
+export interface CachedCategory {
+  id: string;
+  name: string;
+  [key: string]: unknown;
+}
+
 // API Response Types
 export interface MLApiResponse<T> {
   data?: T;


### PR DESCRIPTION
## Summary
- Ensure cached product conversion validates presence of MLProduct
- Introduce CachedUser and CachedCategory interfaces and apply them in cache manager
- Type MercadoLivre API category methods

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any. Specify a different type)*
- `npm run build` *(fails: Cannot apply unknown utility class `bg-primary-500`; invalid GET export)*

------
https://chatgpt.com/codex/tasks/task_e_68c4630e01d883299221cf358ce4e9c6