### PR TITLE
feat: improve typing for paginated Mercado Livre calls

### DIFF
--- a/src/lib/ml-api.ts
+++ b/src/lib/ml-api.ts
@@ -7,7 +7,9 @@ import {
   MLTokenResponse,
   MLTokenRefreshResponse,
   MLSearchResult,
-  MLApiResponse
+  MLApiResponse,
+  AnswerResponse,
+  Paging
 } from '@/types/ml';
 
 class MercadoLivreAPI {
@@ -196,11 +198,11 @@ class MercadoLivreAPI {
 
   // Product Methods
   async getUserProducts(
-    userId?: string, 
+    userId?: string,
     status?: 'active' | 'paused' | 'closed',
     limit = 50,
     offset = 0
-  ): Promise<{ results: string[]; paging: any }> {
+  ): Promise<{ results: string[]; paging: Paging }> {
     const targetUserId = userId || this.userId;
     if (!targetUserId) {
       throw new Error('User ID is required');
@@ -212,7 +214,7 @@ class MercadoLivreAPI {
       ...(status && { status })
     });
 
-    return this.makeRequest<{ results: string[]; paging: any }>(
+    return this.makeRequest<{ results: string[]; paging: Paging }>(
       `/users/${targetUserId}/items/search?${params.toString()}`
     );
   }
@@ -271,8 +273,8 @@ class MercadoLivreAPI {
     return this.makeRequest<MLQuestion>(`/questions/${questionId}`);
   }
 
-  async answerQuestion(questionId: string, answer: string): Promise<any> {
-    return this.makeRequest(`/answers`, {
+  async answerQuestion(questionId: string, answer: string): Promise<AnswerResponse> {
+    return this.makeRequest<AnswerResponse>(`/answers`, {
       method: 'POST',
       body: JSON.stringify({
         question_id: parseInt(questionId),
@@ -285,14 +287,14 @@ class MercadoLivreAPI {
     status?: 'UNANSWERED' | 'ANSWERED',
     limit = 50,
     offset = 0
-  ): Promise<{ questions: MLQuestion[]; paging: any }> {
+  ): Promise<{ questions: MLQuestion[]; paging: Paging }> {
     const params = new URLSearchParams({
       limit: limit.toString(),
       offset: offset.toString(),
       ...(status && { status })
     });
 
-    return this.makeRequest<{ questions: MLQuestion[]; paging: any }>(
+    return this.makeRequest<{ questions: MLQuestion[]; paging: Paging }>(
       `/my/received_questions/search?${params.toString()}`
     );
   }
@@ -303,7 +305,7 @@ class MercadoLivreAPI {
     status?: string,
     limit = 50,
     offset = 0
-  ): Promise<{ results: MLOrder[]; paging: any }> {
+  ): Promise<{ results: MLOrder[]; paging: Paging }> {
     const targetUserId = userId || this.userId;
     if (!targetUserId) {
       throw new Error('User ID is required');
@@ -316,7 +318,7 @@ class MercadoLivreAPI {
       ...(status && { 'order.status': status })
     });
 
-    return this.makeRequest<{ results: MLOrder[]; paging: any }>(
+    return this.makeRequest<{ results: MLOrder[]; paging: Paging }>(
       `/orders/search?${params.toString()}`
     );
   }

--- a/src/types/ml.ts
+++ b/src/types/ml.ts
@@ -165,6 +165,15 @@ export interface MLQuestion {
   tags: string[];
 }
 
+export interface AnswerResponse {
+  id: number;
+  question_id: number;
+  text: string;
+  status: string;
+  item_id: string;
+  date_created: string;
+}
+
 export interface MLOrder {
   id: number;
   status: 'confirmed' | 'payment_required' | 'payment_in_process' | 'paid' | 'shipped' | 'delivered' | 'cancelled';
@@ -333,16 +342,17 @@ export interface MLCategory {
   };
 }
 
+export interface Paging {
+  total: number;
+  limit: number;
+  offset: number;
+}
+
 export interface MLSearchResult {
   site_id: string;
   country_default_time_zone: string;
   query?: string;
-  paging: {
-    total: number;
-    primary_results: number;
-    offset: number;
-    limit: number;
-  };
+  paging: Paging & { primary_results: number };
   results: MLProduct[];
   sort: {
     id: string;


### PR DESCRIPTION
## Summary
- add Paging and AnswerResponse types
- use Paging for paginated user, question and order API methods
- type answerQuestion response

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_68c4663481608329beae56b5c651e4b5