### PR TITLE
Use native transition utilities

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -191,7 +191,7 @@ body {
 @layer components {
   .btn-primary {
     background-color: var(--color-primary-500);
-    @apply text-white px-6 py-3 rounded-lg font-medium transition-peepers shadow-peepers;
+    @apply text-white px-6 py-3 rounded-lg font-medium transition-all duration-300 ease-in-out shadow-peepers;
   }
 
   .btn-primary:hover {
@@ -200,7 +200,7 @@ body {
 
   .btn-secondary {
     background-color: var(--color-secondary-500);
-    @apply text-primary-900 px-6 py-3 rounded-lg font-medium transition-peepers shadow-peepers;
+    @apply text-primary-900 px-6 py-3 rounded-lg font-medium transition-all duration-300 ease-in-out shadow-peepers;
   }
 
   .btn-secondary:hover {
@@ -208,11 +208,11 @@ body {
   }
   
   .card-peepers {
-    @apply bg-white rounded-xl shadow-peepers-lg border border-gray-100 overflow-hidden transition-peepers hover:shadow-xl;
+    @apply bg-white rounded-xl shadow-peepers-lg border border-gray-100 overflow-hidden transition-all duration-300 ease-in-out hover:shadow-xl;
   }
   
   .input-peepers {
-    @apply w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 transition-peepers;
+    @apply w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 transition-all duration-300 ease-in-out;
   }
 
   .input-peepers:focus {


### PR DESCRIPTION
## Summary
- replace `transition-peepers` with `transition-all`, `duration-300`, and `ease-in-out` in component utility classes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: A `require()` style import is forbidden, Unexpected any ...)*

------
https://chatgpt.com/codex/tasks/task_e_68c46c172ad883299fa6bf74ef5c9ba0