### PR TITLE
Ensure user ID is string for ML API access

### DIFF
--- a/src/app/api/ml/sync/route.ts
+++ b/src/app/api/ml/sync/route.ts
@@ -46,7 +46,7 @@ export async function POST(request: NextRequest) {
       console.log('Using access token for user:', tokenData.user_id);
 
       // Set the token in the ML API instance
-      mlApi.setAccessToken(tokenData.token, tokenData.user_id);
+      mlApi.setAccessToken(tokenData.token, tokenData.user_id.toString());
       
       // Sync all products from ML API
       const products = await mlApi.syncAllProducts();

--- a/src/app/api/products/route.ts
+++ b/src/app/api/products/route.ts
@@ -27,7 +27,7 @@ export async function GET(request: NextRequest) {
             console.log('Using ML API fallback with valid token');
             
             // Set token in ML API instance
-            mlApi.setAccessToken(tokenData.token, tokenData.user_id);
+            mlApi.setAccessToken(tokenData.token, tokenData.user_id.toString());
             
             // Fetch products directly from ML API
             const mlProducts = await mlApi.syncAllProducts();


### PR DESCRIPTION
## Summary
- Ensure Mercado Libre access tokens are set with string user ID in sync endpoint
- Ensure Mercado Libre access tokens are set with string user ID in products endpoint

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 22 errors, 13 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68c46cebb6a8832984e8b9189e226b86