### PR TITLE
refactor: replace shadow utilities with explicit box-shadow declarations

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -191,7 +191,8 @@ body {
 @layer components {
   .btn-primary {
     background-color: var(--color-primary-500);
-    @apply text-white px-6 py-3 rounded-lg font-medium transition-all duration-300 ease-in-out shadow-peepers;
+    @apply text-white px-6 py-3 rounded-lg font-medium transition-all duration-300 ease-in-out;
+    box-shadow: var(--shadow-md);
   }
 
   .btn-primary:hover {
@@ -200,7 +201,9 @@ body {
 
   .btn-secondary {
     background-color: var(--color-secondary-500);
-    @apply text-primary-900 px-6 py-3 rounded-lg font-medium transition-all duration-300 ease-in-out shadow-peepers;
+    @apply px-6 py-3 rounded-lg font-medium transition-all duration-300 ease-in-out;
+    color: var(--color-primary-900);
+    box-shadow: var(--shadow-md);
   }
 
   .btn-secondary:hover {
@@ -208,7 +211,8 @@ body {
   }
   
   .card-peepers {
-    @apply bg-white rounded-xl shadow-peepers-lg border border-gray-100 overflow-hidden transition-all duration-300 ease-in-out hover:shadow-xl;
+    @apply bg-white rounded-xl border border-gray-100 overflow-hidden transition-all duration-300 ease-in-out hover:shadow-xl;
+    box-shadow: var(--shadow-lg);
   }
   
   .input-peepers {


### PR DESCRIPTION
## Summary
- remove `@apply` usages for `shadow-peepers` utilities
- add explicit `box-shadow` values using CSS vars
- inline text color for secondary button to avoid unknown utility

## Testing
- `npm run lint` *(fails: A `require()` style import is forbidden, Unexpected any, and other warnings)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c46f2994ec83299f27da7c7546d962