### PR TITLE
feat: use configurable base url

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,7 @@ DATABASE_URL=postgresql://user:password@host:port/database
 # App Configuration
 NEXTAUTH_SECRET=your_nextauth_secret_here
 NEXTAUTH_URL=https://peepers.com.br
+NEXT_PUBLIC_APP_URL=http://localhost:3000
 
 # Vercel (auto-populated in production)
 VERCEL_URL=

--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ This project uses [Vercel KV](https://vercel.com/docs/storage/vercel-kv) to cach
 the cache rely on iterating over keys with `scan`. Scanning is appropriate for small and medium datasets but it requires reading
 through all matching keys and cannot efficiently paginate very large key sets.
 
+## Environment Variables
+
+Set the following variable to configure absolute URLs used in API calls and OAuth redirects:
+
+- `NEXT_PUBLIC_APP_URL` – Base URL of the application (e.g., `https://peepers.vercel.app`).
+
 ## API Authentication
 
 Sensitive API routes require a bearer token for access. Set the `ADMIN_SECRET` environment variable and include it in requests using the `Authorization` header:

--- a/src/app/api/ml/auth/callback/route.ts
+++ b/src/app/api/ml/auth/callback/route.ts
@@ -58,8 +58,12 @@ export async function GET(request: NextRequest) {
     console.log('Exchanging for token...');
 
     // Exchange code for access token with PKCE
-    const redirectUri = 'https://peepers.vercel.app/api/ml/auth/callback';
-    const tokenData = await mlApi.exchangeCodeForToken(code, redirectUri, codeVerifier);
+    const baseUrl = process.env.NEXT_PUBLIC_APP_URL || request.nextUrl.origin;
+    const tokenData = await mlApi.exchangeCodeForToken(
+      code,
+      `${baseUrl}/api/ml/auth/callback`,
+      codeVerifier
+    );
     
     console.log('Token exchange successful:', {
       access_token: tokenData.access_token ? 'received' : 'missing',

--- a/src/app/api/ml/auth/route.ts
+++ b/src/app/api/ml/auth/route.ts
@@ -25,7 +25,8 @@ async function generateCodeChallenge(verifier: string): Promise<string> {
 export async function GET(request: NextRequest) {
   try {
     const clientId = process.env.ML_CLIENT_ID;
-    const redirectUri = 'https://peepers.vercel.app/api/ml/auth/callback';
+    const baseUrl = process.env.NEXT_PUBLIC_APP_URL || request.nextUrl.origin;
+    const redirectUri = `${baseUrl}/api/ml/auth/callback`;
     
     if (!clientId) {
       return NextResponse.json(

--- a/src/app/api/ml/test-token/route.ts
+++ b/src/app/api/ml/test-token/route.ts
@@ -13,6 +13,7 @@ export async function GET(request: NextRequest) {
 
     console.log('Testing token exchange with code:', code);
 
+    const baseUrl = process.env.NEXT_PUBLIC_APP_URL || request.nextUrl.origin;
     // Direct API call to ML
     const tokenResponse = await fetch('https://api.mercadolibre.com/oauth/token', {
       method: 'POST',
@@ -25,7 +26,7 @@ export async function GET(request: NextRequest) {
         client_id: process.env.ML_CLIENT_ID!,
         client_secret: process.env.ML_CLIENT_SECRET!,
         code: code,
-        redirect_uri: 'https://peepers.vercel.app/api/ml/auth/callback'
+        redirect_uri: `${baseUrl}/api/ml/auth/callback`
       })
     });
 

--- a/src/app/produtos/page.tsx
+++ b/src/app/produtos/page.tsx
@@ -8,7 +8,9 @@ import type { ProductSummary } from '@/types/product';
 async function ProductsList() {
   try {
     // Buscar produtos reais da API
-    const response = await fetch(`${process.env.NEXTAUTH_URL || 'https://peepers.vercel.app'}/api/products`, {
+    const baseUrl =
+      process.env.NEXT_PUBLIC_APP_URL || process.env.NEXTAUTH_URL || '';
+    const response = await fetch(`${baseUrl}/api/products`, {
       cache: 'no-store' // Sempre buscar dados atualizados
     });
     

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,7 @@
 {
+  "env": {
+    "NEXT_PUBLIC_APP_URL": "https://peepers.vercel.app"
+  },
   "functions": {
     "src/app/api/ml/webhook/route.ts": {
       "maxDuration": 10


### PR DESCRIPTION
## Summary
- remove hard-coded peepers.vercel.app references
- derive OAuth callback URLs from env/request
- document `NEXT_PUBLIC_APP_URL` in env config and docs

## Testing
- ⚠️ `npm test` (Missing script: "test")
- ⚠️ `npm run lint` (Unexpected any. Specify a different type)
- ✅ `npx eslint src/app/produtos/page.tsx src/app/api/ml/auth/route.ts src/app/api/ml/auth/callback/route.ts src/app/api/ml/test-token/route.ts`

------
https://chatgpt.com/codex/tasks/task_e_68c4703106d483299f25d9861b5afd34