### PR TITLE
fix: run ML webhook on node runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,7 @@ This token is required when calling:
 - `POST /api/products/[id]`
 
 Requests without the correct token will receive a `401 Unauthorized` response.
+
+## Runtime Requirements
+
+The `/api/ml/webhook` endpoint uses `revalidatePath` to update ISR pages and therefore runs on the Node.js runtime rather than the Edge runtime.

--- a/src/app/api/ml/webhook/route.ts
+++ b/src/app/api/ml/webhook/route.ts
@@ -4,7 +4,8 @@ import { mlApi } from '@/lib/ml-api';
 import { cache } from '@/lib/cache';
 import { revalidatePath } from 'next/cache';
 
-export const runtime = 'edge';
+// revalidatePath requires the Node.js runtime
+export const runtime = 'node';
 export const maxDuration = 10;
 
 export async function POST(request: NextRequest) {


### PR DESCRIPTION
## Summary
- run `/api/ml/webhook` on the Node.js runtime because `revalidatePath` is not supported on Edge
- document runtime requirements for the webhook endpoint

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_68c47add92d0832981dd7c297178af93