### PR TITLE
Escape HTML in auth callback

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "test": "tsx src/app/api/ml/webhook/route.test.ts"
+    "test": "tsx src/app/api/ml/webhook/route.test.ts && tsx src/lib/html.test.ts"
   },
   "dependencies": {
     "@tailwindcss/forms": "^0.5.10",

--- a/src/app/api/ml/auth/callback/route.ts
+++ b/src/app/api/ml/auth/callback/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { mlApi } from '@/lib/ml-api';
 import { cache } from '@/lib/cache';
+import { html } from '@/lib/html';
 
 // Removed edge runtime - incompatible with Redis operations
 
@@ -85,17 +86,18 @@ export async function GET(request: NextRequest) {
     });
 
     // Create response with success page
-    const response = new NextResponse(`
+    const response = new NextResponse(
+      html`
       <!DOCTYPE html>
       <html>
         <head>
           <title>Peepers - Autorização Concluída</title>
           <meta charset="utf-8">
           <style>
-            body { 
-              font-family: Arial, sans-serif; 
-              max-width: 600px; 
-              margin: 50px auto; 
+            body {
+              font-family: Arial, sans-serif;
+              max-width: 600px;
+              margin: 50px auto;
               padding: 20px;
               text-align: center;
             }
@@ -115,7 +117,7 @@ export async function GET(request: NextRequest) {
         <body>
           <h1 class="success">✅ Autorização Concluída!</h1>
           <p>Sua conta do Mercado Livre foi conectada com sucesso à Peepers.</p>
-          
+
           <div class="info">
             <strong>Próximos passos:</strong><br>
             • Seus produtos serão sincronizados automaticamente<br>
@@ -125,15 +127,17 @@ export async function GET(request: NextRequest) {
 
           <a href="/" class="button">Voltar ao Site</a>
           <a href="/api/ml/sync?action=sync" class="button">Sincronizar Produtos Agora</a>
-          
+
           <p><small>User ID: ${tokenData.user_id}</small></p>
         </body>
       </html>
-    `, {
-      headers: {
-        'Content-Type': 'text/html',
-      },
-    });
+    `,
+      {
+        headers: {
+          'Content-Type': 'text/html',
+        },
+      }
+    );
 
     // Clear the code_verifier cookie after successful token exchange
     response.cookies.set('ml_code_verifier', '', {
@@ -157,18 +161,20 @@ export async function GET(request: NextRequest) {
 
   } catch (error) {
     console.error('OAuth callback error:', error);
-    
-    return new NextResponse(`
+
+    const message = error instanceof Error ? error.message : 'Erro desconhecido';
+    return new NextResponse(
+      html`
       <!DOCTYPE html>
       <html>
         <head>
           <title>Peepers - Erro na Autorização</title>
           <meta charset="utf-8">
           <style>
-            body { 
-              font-family: Arial, sans-serif; 
-              max-width: 600px; 
-              margin: 50px auto; 
+            body {
+              font-family: Arial, sans-serif;
+              max-width: 600px;
+              margin: 50px auto;
               padding: 20px;
               text-align: center;
             }
@@ -187,17 +193,19 @@ export async function GET(request: NextRequest) {
         <body>
           <h1 class="error">❌ Erro na Autorização</h1>
           <p>Ocorreu um erro ao conectar sua conta do Mercado Livre.</p>
-          <p><strong>Erro:</strong> ${error instanceof Error ? error.message : 'Erro desconhecido'}</p>
-          
+          <p><strong>Erro:</strong> ${message}</p>
+
           <a href="/api/ml/auth" class="button">Tentar Novamente</a>
           <a href="/" class="button">Voltar ao Site</a>
         </body>
       </html>
-    `, {
-      status: 500,
-      headers: {
-        'Content-Type': 'text/html',
-      },
-    });
+    `,
+      {
+        status: 500,
+        headers: {
+          'Content-Type': 'text/html',
+        },
+      }
+    );
   }
 }

--- a/src/lib/html.test.ts
+++ b/src/lib/html.test.ts
@@ -1,0 +1,8 @@
+import assert from 'node:assert/strict';
+import { html } from './html';
+
+const dangerous = '<script>alert("xss")</script>';
+const output = html`<div>${dangerous}</div>`;
+assert.ok(!output.includes(dangerous));
+assert.ok(output.includes('&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;'));
+console.log('HTML escaping test passed');

--- a/src/lib/html.ts
+++ b/src/lib/html.ts
@@ -1,0 +1,20 @@
+export function escapeHtml(value: string): string {
+  const map: Record<string, string> = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;'
+  };
+  return value.replace(/[&<>"']/g, (ch) => map[ch] ?? ch);
+}
+
+export function html(strings: TemplateStringsArray, ...values: unknown[]): string {
+  return strings.reduce((result, str, i) => {
+    const val = values[i];
+    if (val === undefined || val === null) {
+      return result + str;
+    }
+    return result + str + escapeHtml(String(val));
+  }, '');
+}


### PR DESCRIPTION
## Summary
- Add HTML template helper with entity escaping
- Render OAuth callback responses with escaped template
- Add test confirming HTML is sanitized

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c49acaef9883299b4a89af01a3cd25