### PR TITLE
Refactor KV client initialization and add tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "test": "tsx src/app/api/ml/webhook/route.test.ts && tsx src/lib/html.test.ts"
+    "test": "tsx src/lib/cache.test.ts && tsx src/app/api/ml/webhook/route.test.ts && tsx src/lib/html.test.ts"
   },
   "dependencies": {
     "@tailwindcss/forms": "^0.5.10",

--- a/src/lib/cache.test.ts
+++ b/src/lib/cache.test.ts
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict';
+import { getKVClient, __resetKVClient } from './cache';
+
+const originalUrl = process.env.UPSTASH_REDIS_REST_URL;
+const originalToken = process.env.UPSTASH_REDIS_REST_TOKEN;
+
+delete process.env.UPSTASH_REDIS_REST_URL;
+delete process.env.UPSTASH_REDIS_REST_TOKEN;
+
+assert.throws(() => getKVClient(), /Missing environment variable: UPSTASH_REDIS_REST_URL/);
+
+process.env.UPSTASH_REDIS_REST_URL = 'https://example.com';
+process.env.UPSTASH_REDIS_REST_TOKEN = 'test';
+
+assert.doesNotThrow(() => getKVClient());
+
+__resetKVClient();
+process.env.UPSTASH_REDIS_REST_URL = originalUrl;
+process.env.UPSTASH_REDIS_REST_TOKEN = originalToken;
+
+console.log('Cache client initialization tests passed');


### PR DESCRIPTION
## Summary
- Lazily initialize the KV client and validate required env vars
- Run tests for successful and failing cache client initialization
- Wire new test into the npm test script

## Testing
- `npm test`
- `npm run lint` *(fails: A `require()` style import is forbidden, Unexpected any, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c4a05e64048329956a636f39d9709c