### PR TITLE
feat: use helper for HTML responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "test": "tsx src/lib/cache.test.ts && tsx src/app/api/ml/webhook/route.test.ts && tsx src/lib/html.test.ts"
+    "test": "tsx src/lib/cache.test.ts && tsx src/app/api/ml/webhook/route.test.ts && tsx src/lib/html.test.ts && tsx src/lib/render-html.test.ts"
   },
   "dependencies": {
     "@tailwindcss/forms": "^0.5.10",

--- a/src/app/api/ml/auth/callback/route.ts
+++ b/src/app/api/ml/auth/callback/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { mlApi } from '@/lib/ml-api';
 import { cache } from '@/lib/cache';
 import { html } from '@/lib/html';
+import { renderHtml } from '@/lib/render-html';
 
 // Removed edge runtime - incompatible with Redis operations
 
@@ -86,7 +87,7 @@ export async function GET(request: NextRequest) {
     });
 
     // Create response with success page
-    const response = new NextResponse(
+    const response = renderHtml(
       html`
       <!DOCTYPE html>
       <html>
@@ -131,12 +132,7 @@ export async function GET(request: NextRequest) {
           <p><small>User ID: ${tokenData.user_id}</small></p>
         </body>
       </html>
-    `,
-      {
-        headers: {
-          'Content-Type': 'text/html',
-        },
-      }
+    `
     );
 
     // Clear the code_verifier cookie after successful token exchange
@@ -163,7 +159,7 @@ export async function GET(request: NextRequest) {
     console.error('OAuth callback error:', error);
 
     const message = error instanceof Error ? error.message : 'Erro desconhecido';
-    return new NextResponse(
+    return renderHtml(
       html`
       <!DOCTYPE html>
       <html>
@@ -200,12 +196,7 @@ export async function GET(request: NextRequest) {
         </body>
       </html>
     `,
-      {
-        status: 500,
-        headers: {
-          'Content-Type': 'text/html',
-        },
-      }
+      { status: 500 }
     );
   }
 }

--- a/src/app/api/ml/sync/route.ts
+++ b/src/app/api/ml/sync/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { mlApi } from '@/lib/ml-api';
 import { cache } from '@/lib/cache';
+import { renderHtml } from '@/lib/render-html';
 
 // Removed edge runtime - incompatible with Redis operations
 export const maxDuration = 30;
@@ -93,17 +94,17 @@ export async function GET(request: NextRequest) {
     
     if (action === 'sync') {
       // Redirect to POST for actual sync
-      return new NextResponse(`
+      return renderHtml(`
         <!DOCTYPE html>
         <html>
           <head>
             <title>Peepers - Sincronizando Produtos</title>
             <meta charset="utf-8">
             <style>
-              body { 
-                font-family: Arial, sans-serif; 
-                max-width: 600px; 
-                margin: 50px auto; 
+              body {
+                font-family: Arial, sans-serif;
+                max-width: 600px;
+                margin: 50px auto;
                 padding: 20px;
                 text-align: center;
               }
@@ -125,9 +126,9 @@ export async function GET(request: NextRequest) {
           <body>
             <h1 class="loading">🔄 Sincronizando Produtos...</h1>
             <p>Aguarde enquanto sincronizamos seus produtos do Mercado Livre.</p>
-            
+
             <div id="result"></div>
-            
+
             <script>
               async function syncProducts() {
                 try {
@@ -137,10 +138,10 @@ export async function GET(request: NextRequest) {
                       'Content-Type': 'application/json'
                     }
                   });
-                  
+
                   const data = await response.json();
                   const resultDiv = document.getElementById('result');
-                  
+
                   if (response.ok) {
                     resultDiv.innerHTML = \`
                       <div class="result success">
@@ -172,17 +173,13 @@ export async function GET(request: NextRequest) {
                   \`;
                 }
               }
-              
+
               // Start sync automatically
               syncProducts();
             </script>
           </body>
         </html>
-      `, {
-        headers: {
-          'Content-Type': 'text/html',
-        },
-      });
+      `);
     }
     
     // Default GET behavior - return sync status

--- a/src/lib/render-html.test.ts
+++ b/src/lib/render-html.test.ts
@@ -1,0 +1,13 @@
+import assert from 'node:assert/strict';
+import { renderHtml } from './render-html';
+import { html } from './html';
+
+(async () => {
+  const response = renderHtml(html`<h1>${'Hello'}</h1>`, { status: 201 });
+  assert.equal(response.status, 201);
+  assert.equal(response.headers.get('Content-Type'), 'text/html');
+  const text = await response.text();
+  assert.equal(text, '<h1>Hello</h1>');
+
+  console.log('renderHtml helper test passed');
+})();

--- a/src/lib/render-html.ts
+++ b/src/lib/render-html.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from 'next/server';
+
+export function renderHtml(content: string, init: ResponseInit = {}): NextResponse {
+  const headers = new Headers(init.headers);
+  headers.set('Content-Type', 'text/html');
+  return new NextResponse(content, { ...init, headers });
+}


### PR DESCRIPTION
## Summary
- add `renderHtml` helper for consistent HTML response generation
- replace manual HTML construction in auth callback and ML sync routes
- test HTML rendering helper

## Testing
- `npm test`
- `npm run lint` *(fails: A `require()` style import is forbidden, Unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_68c4a8a945f0832983b1338fbcba7826