### PR TITLE
refactor: inject HTTP client and credentials

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "test": "tsx src/lib/cache.test.ts && tsx src/app/api/ml/webhook/route.test.ts && tsx src/lib/html.test.ts && tsx src/lib/render-html.test.ts"
+    "test": "tsx src/lib/cache.test.ts && tsx src/app/api/ml/webhook/route.test.ts && tsx src/lib/html.test.ts && tsx src/lib/render-html.test.ts && tsx src/lib/ml-api.test.ts"
   },
   "dependencies": {
     "@tailwindcss/forms": "^0.5.10",

--- a/src/app/api/ml/auth/callback/route.ts
+++ b/src/app/api/ml/auth/callback/route.ts
@@ -1,8 +1,19 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { mlApi } from '@/lib/ml-api';
 import { cache } from '@/lib/cache';
 import { html } from '@/lib/html';
 import { renderHtml } from '@/lib/render-html';
+import { createMercadoLivreAPI } from '@/lib/ml-api';
+
+const mlApi = createMercadoLivreAPI(
+  { fetch },
+  {
+    clientId: process.env.ML_CLIENT_ID!,
+    clientSecret: process.env.ML_CLIENT_SECRET!,
+    accessToken: process.env.ML_ACCESS_TOKEN,
+    refreshToken: process.env.ML_REFRESH_TOKEN,
+    userId: process.env.ML_USER_ID
+  }
+);
 
 // Removed edge runtime - incompatible with Redis operations
 

--- a/src/app/api/ml/sync/route.ts
+++ b/src/app/api/ml/sync/route.ts
@@ -1,7 +1,18 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { mlApi } from '@/lib/ml-api';
 import { cache } from '@/lib/cache';
 import { renderHtml } from '@/lib/render-html';
+import { createMercadoLivreAPI } from '@/lib/ml-api';
+
+const mlApi = createMercadoLivreAPI(
+  { fetch },
+  {
+    clientId: process.env.ML_CLIENT_ID!,
+    clientSecret: process.env.ML_CLIENT_SECRET!,
+    accessToken: process.env.ML_ACCESS_TOKEN,
+    refreshToken: process.env.ML_REFRESH_TOKEN,
+    userId: process.env.ML_USER_ID
+  }
+);
 
 // Removed edge runtime - incompatible with Redis operations
 export const maxDuration = 30;

--- a/src/app/api/ml/webhook/route.ts
+++ b/src/app/api/ml/webhook/route.ts
@@ -1,9 +1,20 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { MLWebhook } from '@/types/ml';
-import { mlApi } from '@/lib/ml-api';
 import { cache } from '@/lib/cache';
 import { revalidatePath } from 'next/cache';
 import crypto from 'node:crypto';
+import { createMercadoLivreAPI } from '@/lib/ml-api';
+
+const mlApi = createMercadoLivreAPI(
+  { fetch },
+  {
+    clientId: process.env.ML_CLIENT_ID!,
+    clientSecret: process.env.ML_CLIENT_SECRET!,
+    accessToken: process.env.ML_ACCESS_TOKEN,
+    refreshToken: process.env.ML_REFRESH_TOKEN,
+    userId: process.env.ML_USER_ID
+  }
+);
 
 // revalidatePath requires the Node.js runtime
 export const runtime = 'nodejs';

--- a/src/app/api/products/[id]/route.ts
+++ b/src/app/api/products/[id]/route.ts
@@ -1,6 +1,17 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { mlApi } from '@/lib/ml-api';
 import { cache } from '@/lib/cache';
+import { createMercadoLivreAPI } from '@/lib/ml-api';
+
+const mlApi = createMercadoLivreAPI(
+  { fetch },
+  {
+    clientId: process.env.ML_CLIENT_ID!,
+    clientSecret: process.env.ML_CLIENT_SECRET!,
+    accessToken: process.env.ML_ACCESS_TOKEN,
+    refreshToken: process.env.ML_REFRESH_TOKEN,
+    userId: process.env.ML_USER_ID
+  }
+);
 
 export async function GET(
   request: NextRequest,

--- a/src/app/api/products/route.ts
+++ b/src/app/api/products/route.ts
@@ -1,6 +1,17 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { cache } from '@/lib/cache';
-import { mlApi } from '@/lib/ml-api';
+import { createMercadoLivreAPI } from '@/lib/ml-api';
+
+const mlApi = createMercadoLivreAPI(
+  { fetch },
+  {
+    clientId: process.env.ML_CLIENT_ID!,
+    clientSecret: process.env.ML_CLIENT_SECRET!,
+    accessToken: process.env.ML_ACCESS_TOKEN,
+    refreshToken: process.env.ML_REFRESH_TOKEN,
+    userId: process.env.ML_USER_ID
+  }
+);
 
 // Removed edge runtime - incompatible with Redis operations
 

--- a/src/lib/ml-api.test.ts
+++ b/src/lib/ml-api.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import { MercadoLivreAPI, HttpClient } from './ml-api';
+
+class MockResponse {
+  constructor(private data: unknown, public ok = true, public status = 200, public statusText = 'OK') {}
+  async json() {
+    return this.data;
+  }
+}
+
+class MockClient implements HttpClient {
+  lastUrl?: string;
+  lastInit?: RequestInit;
+  constructor(private response: MockResponse) {}
+  async fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+    this.lastUrl = String(input);
+    this.lastInit = init;
+    return this.response as unknown as Response;
+  }
+}
+
+(async () => {
+  const mockData = { id: '123', title: 'Test Product' };
+  const client = new MockClient(new MockResponse(mockData));
+  const api = new MercadoLivreAPI(client, 'id', 'secret', { accessToken: 'token' });
+
+  const product = await api.getProduct('123');
+
+  assert.deepEqual(product, mockData);
+  assert.equal(client.lastUrl, 'https://api.mercadolibre.com/items/123');
+  const headers = client.lastInit?.headers as Record<string, string>;
+  assert.equal(headers['Authorization'], 'Bearer token');
+
+  console.log('MercadoLivreAPI HTTP client tests passed');
+})();


### PR DESCRIPTION
## Summary
- introduce `HttpClient` interface and constructor injection for MercadoLivreAPI
- create factory to build API instances with supplied tokens
- wire routes to provide dependencies explicitly
- add tests with mocked HTTP client

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_68c4acf1e09c8329ae45cb7cde04b327