### PR TITLE
Use constant-time admin token comparison

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "ts-node": "^10.9.2",
         "tsx": "^4.20.5",
         "typescript": "^5",
+        "vite-tsconfig-paths": "^4.3.1",
         "vitest": "^3.2.4"
       }
     },
@@ -4985,6 +4986,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -7896,6 +7904,27 @@
         }
       }
     },
+    "node_modules/tsconfck": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
+      "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tsconfck": "bin/tsconfck.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -8226,6 +8255,26 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-tsconfig-paths": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-4.3.2.tgz",
+      "integrity": "sha512-0Vd/a6po6Q+86rPlntHye7F31zA2URZMbH8M3saAZ/xR9QoGN/L21bxEGfXdWmFdNkqPpRdxFT7nmNe12e9/uA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "globrex": "^0.1.2",
+        "tsconfck": "^3.0.3"
+      },
+      "peerDependencies": {
+        "vite": "*"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
       }
     },
     "node_modules/vite/node_modules/fdir": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "ts-node": "^10.9.2",
     "tsx": "^4.20.5",
     "typescript": "^5",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.4",
+    "vite-tsconfig-paths": "^4.3.1"
   }
 }

--- a/src/app/api/ml/sync/route.test.ts
+++ b/src/app/api/ml/sync/route.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+describe('POST /api/ml/sync auth', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    process.env.ML_CLIENT_ID = 'id';
+    process.env.ML_CLIENT_SECRET = 'secret';
+    process.env.ML_ACCESS_TOKEN = 'access';
+    process.env.ML_REFRESH_TOKEN = 'refresh';
+    process.env.ML_USER_ID = '123';
+  });
+
+  it('returns 401 for invalid token', async () => {
+    process.env.ADMIN_SECRET = 's3cr3t';
+    const { POST } = await import('./route');
+    const req = { headers: new Headers({ authorization: 'Bearer wrong' }) } as any;
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 when secret missing', async () => {
+    delete process.env.ADMIN_SECRET;
+    const { POST } = await import('./route');
+    const req = { headers: new Headers({ authorization: 'Bearer whatever' }) } as any;
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 200 for valid token', async () => {
+    process.env.ADMIN_SECRET = 's3cr3t';
+    vi.mock('@/lib/cache', () => ({
+      cache: {
+        acquireSyncLock: vi.fn().mockResolvedValue(true),
+        getUser: vi.fn().mockResolvedValue({ token: 't', user_id: '123', expires_at: new Date(Date.now()+1000).toISOString() }),
+        setAllProducts: vi.fn().mockResolvedValue(undefined),
+        releaseSyncLock: vi.fn().mockResolvedValue(undefined),
+        getCacheStats: vi.fn(),
+        getLastSyncTime: vi.fn(),
+      },
+    }));
+    vi.mock('@/lib/ml-api', () => ({
+      createMercadoLivreAPI: () => ({
+        setAccessToken: vi.fn(),
+        syncAllProducts: vi.fn().mockResolvedValue([]),
+      }),
+    }));
+    const { POST } = await import('./route');
+    const req = { headers: new Headers({ authorization: 'Bearer s3cr3t' }) } as any;
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+  });
+});

--- a/src/app/api/ml/sync/route.ts
+++ b/src/app/api/ml/sync/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { timingSafeEqual } from 'crypto';
 import { cache } from '@/lib/cache';
 import { renderHtml } from '@/lib/render-html';
 import { createMercadoLivreAPI } from '@/lib/ml-api';
@@ -20,7 +21,24 @@ export const maxDuration = 30;
 export async function POST(request: NextRequest) {
   // Require admin token for manual sync
   const authHeader = request.headers.get('authorization');
-  if (authHeader !== `Bearer ${process.env.ADMIN_SECRET}`) {
+  const adminSecret = process.env.ADMIN_SECRET;
+  const token = authHeader?.replace(/^Bearer\s+/i, '') || '';
+
+  if (!adminSecret) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const tokenBuffer = Buffer.from(token);
+    const secretBuffer = Buffer.from(adminSecret);
+    const match =
+      tokenBuffer.length === secretBuffer.length &&
+      timingSafeEqual(tokenBuffer, secretBuffer);
+
+    if (!match) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+  } catch {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from 'vitest/config';
+import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig({
+  plugins: [tsconfigPaths()],
   test: {
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
## Summary
- guard `/api/ml/sync` with constant-time token check
- add tests for valid and invalid admin tokens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c56f48ee508329b2ff3c0392945524