### PR TITLE
chore: rename upstash env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,8 +6,8 @@ ML_REFRESH_TOKEN=your_refresh_token_here
 ML_USER_ID=your_user_id_here
 
 # Cache (Redis)
-KV_REST_API_URL=your_upstash_redis_url
-KV_REST_API_TOKEN=your_upstash_redis_token
+UPSTASH_REDIS_REST_URL=your_upstash_redis_url
+UPSTASH_REDIS_REST_TOKEN=your_upstash_redis_token
 
 # Database (PostgreSQL) - Optional for MVP
 DATABASE_URL=postgresql://user:password@host:port/database


### PR DESCRIPTION
## Summary
- rename Upstash environment variables in `.env.example`

## Testing
- `npm test`
- `npx --yes vercel --version` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68c579f41be8832982e823a83608d509